### PR TITLE
move dev-only dependency into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   "homepage": "https://github.com/mickhansen/retry-as-promised",
   "dependencies": {
     "bluebird": "^3.4.6",
-    "cross-env": "^3.1.2",
     "debug": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",
     "chai-as-promised": "^5.0.0",
+    "cross-env": "^3.1.2",
     "mocha": "^2.2.5",
     "moment": "^2.10.6",
     "q": "^1.4.1",


### PR DESCRIPTION
`cross-env` is only required for development and not when using/consuming this library.