### PR TITLE
Remove unnecessary logging and default  to 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ module.exports = function retryAsPromised(callback, options) {
 
   // Super cheap clone
   options = {
-    $current:         options.$current || 0, // default to 0
-    max:              options.max, // number of retries
+    $current:         options.$current || 1,
+    max:              options.max,
     timeout:          options.timeout || undefined,
     match:            options.match || [],
     backoffBase:      options.backoffBase === undefined ? 100 : options.backoffBase,
@@ -25,7 +25,7 @@ module.exports = function retryAsPromised(callback, options) {
   if (!Array.isArray(options.match)) options.match = [options.match];
 
   debug('Trying '+ options.name + ' (%s)', options.$current);
-  if(options.report && options.$current > 0) options.report('Retrying ' + options.name + ' #' + options.$current + ' at ' + new Date().toLocaleTimeString(), options);
+  if(options.report) options.report('Retrying ' + options.name + ' #' + options.$current + ' at ' + new Date().toLocaleTimeString(), options);
 
   return new Promise(function (resolve, reject) {
     var timeout, backoffTimeout;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function retryAsPromised(callback, options) {
   if (!Array.isArray(options.match)) options.match = [options.match];
 
   debug('Trying '+ options.name + ' (%s)', options.$current);
-  if(options.report) options.report('Retrying ' + options.name + ' #' + options.$current + ' at ' + new Date().toLocaleTimeString(), options);
+  if(options.report) options.report('Trying ' + options.name + ' #' + options.$current + ' at ' + new Date().toLocaleTimeString(), options);
 
   return new Promise(function (resolve, reject) {
     var timeout, backoffTimeout;


### PR DESCRIPTION
Hi there. I like this tool a lot and want to go to production with it asap. Here are some changes I am suggesting.

1. `options.$current || 0`
 change the default to 0. This will mean that if `max = 3` it will actually attempt to retry 3 times (instead of 2 retries). 

2. Remove unnecessary logging from the `report` function. Logging within the `report` function is useless if there are 3 logs for each retry ("Try ...",  "Delaying ...", "Trying ..."). 

**Example case (regarding change 2)**: 
I want to record `#calls to myFunction() vs #retries on myFunction()`. 
Say for example I set my max = 3 and want to `return myFunction()`. I monitor (using statsd for example) each time `myFunction()` is called and each time it retries using the `record`. Say  `myFunction()` is called 3 times (and throws), it will appear to have been called 9 times... because you have 3 reports for a single retry. This will mean my `#calls to myFunction() vs #retries on myFunction()` will be `3 vs 9` instead of `3 vs 3`. This is assuming `myFunction()` throws on every attempt.

**Note:** 
Like I said already, I would like to go to production with this on Monday but would wait for you to merge these changes if you agree with them. Please let me know what you think 👍 