### PR TITLE
added: expose to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ var retry = require('retry-as-promised');
 var warningFn = function(msg){ someLoggingFunction(msg, 'notice'); };
 
 // Will call the until max retries or the promise is resolved.
-return retry(function () {
+return retry(function (options) {
+  // options.current, times callback has been called including this call
   return promise;
 }, {
   max: 3, // maximum amount of tries

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function retryAsPromised(callback, options) {
       }, options.timeout);
     }
 
-    Promise.resolve(callback()).then(resolve).tap(function () {
+    Promise.resolve(callback({ $current: options.$current })).then(resolve).tap(function () {
       if (timeout) clearTimeout(timeout);
       if (backoffTimeout) clearTimeout(backoffTimeout);
     }).catch(function (err) {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function retryAsPromised(callback, options) {
       }, options.timeout);
     }
 
-    Promise.resolve(callback({ $current: options.$current })).then(resolve).tap(function () {
+    Promise.resolve(callback({ current: options.$current })).then(resolve).tap(function () {
       if (timeout) clearTimeout(timeout);
       if (backoffTimeout) clearTimeout(backoffTimeout);
     }).catch(function (err) {

--- a/test/bluebird.test.js
+++ b/test/bluebird.test.js
@@ -42,6 +42,9 @@ describe('bluebird', function () {
     var callback = sinon.stub();
     callback.rejects(soRejected);
     return expect(retry(callback, {max: 3, backoffBase: 0})).to.eventually.be.rejectedWith(soRejected).then(function () {
+      expect(callback.firstCall.args).to.deep.equal([{ $current: 1 }]);
+      expect(callback.secondCall.args).to.deep.equal([{ $current: 2 }]);
+      expect(callback.thirdCall.args).to.deep.equal([{ $current: 3 }]);
       expect(callback.callCount).to.equal(3);
     });
   });
@@ -60,6 +63,9 @@ describe('bluebird', function () {
     callback.rejects(soRejected);
     callback.onCall(3).resolves(soResolved);
     return expect(retry(callback, {max: 10, backoffBase: 0})).to.eventually.equal(soResolved).then(function () {
+      expect(callback.firstCall.args).to.deep.equal([{ $current: 1 }]);
+      expect(callback.secondCall.args).to.deep.equal([{ $current: 2 }]);
+      expect(callback.thirdCall.args).to.deep.equal([{ $current: 3 }]);
       expect(callback.callCount).to.equal(4);
     });
   });
@@ -91,7 +97,7 @@ describe('bluebird', function () {
       });
     });
   });
-  
+
   describe('match', function () {
     it('should continue retry while error is equal to match string', function () {
       var callback = sinon.stub();
@@ -101,7 +107,7 @@ describe('bluebird', function () {
         expect(callback.callCount).to.equal(4);
       });
     });
-    
+
     it('should reject immediately if error is not equal to match string', function () {
       var callback = sinon.stub();
       callback.rejects(soRejected);
@@ -109,7 +115,7 @@ describe('bluebird', function () {
         expect(callback.callCount).to.equal(1);
       });
     });
-    
+
     it('should continue retry while error is instanceof match', function () {
       var callback = sinon.stub();
       callback.rejects(soRejected);
@@ -126,7 +132,7 @@ describe('bluebird', function () {
         expect(callback.callCount).to.equal(1);
       });
     });
-    
+
     it('should continue retry while error is equal to match string in array', function () {
       var callback = sinon.stub();
       callback.rejects(soRejected);
@@ -173,7 +179,7 @@ describe('bluebird', function () {
         expect(moment().diff(startTime)).to.be.above(3400);
       });
     });
-    
+
     it('should throw TimeoutError and cancel backoff delay if timeout is reached', function () {
       return expect(retry(function () {
         return Promise.delay(2000);

--- a/test/bluebird.test.js
+++ b/test/bluebird.test.js
@@ -42,9 +42,9 @@ describe('bluebird', function () {
     var callback = sinon.stub();
     callback.rejects(soRejected);
     return expect(retry(callback, {max: 3, backoffBase: 0})).to.eventually.be.rejectedWith(soRejected).then(function () {
-      expect(callback.firstCall.args).to.deep.equal([{ $current: 1 }]);
-      expect(callback.secondCall.args).to.deep.equal([{ $current: 2 }]);
-      expect(callback.thirdCall.args).to.deep.equal([{ $current: 3 }]);
+      expect(callback.firstCall.args).to.deep.equal([{ current: 1 }]);
+      expect(callback.secondCall.args).to.deep.equal([{ current: 2 }]);
+      expect(callback.thirdCall.args).to.deep.equal([{ current: 3 }]);
       expect(callback.callCount).to.equal(3);
     });
   });
@@ -63,9 +63,9 @@ describe('bluebird', function () {
     callback.rejects(soRejected);
     callback.onCall(3).resolves(soResolved);
     return expect(retry(callback, {max: 10, backoffBase: 0})).to.eventually.equal(soResolved).then(function () {
-      expect(callback.firstCall.args).to.deep.equal([{ $current: 1 }]);
-      expect(callback.secondCall.args).to.deep.equal([{ $current: 2 }]);
-      expect(callback.thirdCall.args).to.deep.equal([{ $current: 3 }]);
+      expect(callback.firstCall.args).to.deep.equal([{ current: 1 }]);
+      expect(callback.secondCall.args).to.deep.equal([{ current: 2 }]);
+      expect(callback.thirdCall.args).to.deep.equal([{ current: 3 }]);
       expect(callback.callCount).to.equal(4);
     });
   });


### PR DESCRIPTION
Although this can be achieved by a local variable incremented in each call, I will still prefer `retry-as-promised` expose its internal indicator to callback as `{ $current: n }`