### PR TITLE
Updated debug dependency to ^2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mickhansen/retry-as-promised",
   "dependencies": {
     "bluebird": "^3.4.6",
-    "debug": "^2.2.0"
+    "debug": "^2.6.9"
   },
   "devDependencies": {
     "chai": "^2.3.0",


### PR DESCRIPTION
This resolves a REDoS vulnerability in debug as detailed at https://nodesecurity.io/advisories/534

Ref #10 