### PR TITLE
Fix initial retry delay so that it uses the unmodified backoffBase

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,17 +67,18 @@ module.exports = function retryAsPromised(callback, options) {
 
       if (!shouldRetry) return reject(err);
 
+      var retryDelay = Math.pow(options.backoffBase, Math.pow(options.backoffExponent, (options.$current - 1)));
+
       // Do some accounting
       options.$current++;
       debug('Retrying '+ options.name + ' (%s)', options.$current);
-      if (options.backoffBase) {
+      if (retryDelay) {
         // Use backoff function to ease retry rate
-        options.backoffBase = Math.pow(options.backoffBase, options.backoffExponent);
-        debug('Delaying retry of '+ options.name+' by %s', options.backoffBase);
-        if(options.report) options.report('Delaying retry of ' + options.name + ' by ' + options.backoffBase, options);
+        debug('Delaying retry of ' + options.name + ' by %s', retryDelay);
+        if(options.report) options.report('Delaying retry of ' + options.name + ' by ' + retryDelay, options);
         backoffTimeout = setTimeout(function() {
           retryAsPromised(callback, options).then(resolve).catch(reject);
-        }, options.backoffBase);
+        }, retryDelay);
       } else {
         retryAsPromised(callback, options).then(resolve).catch(reject);
       }


### PR DESCRIPTION
Fixes #12 

Though technically a fix of something unintentional, this change may qualify as breaking (i.e. worthy of a major version bump) since it could significantly affect delay durations for existing users.