### PR TITLE
add support for function as match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function TimeoutError(message, err) {
   Error.captureStackTrace(this, TimeoutError);
   this.name = 'TimeoutError';
   this.message = message;
-  this.original = err;
+  this.previous = err;
 }
 
 util.inherits(TimeoutError, Error);

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -276,7 +276,26 @@ describe(PROMISE_TYPE, function() {
           expect(callback.callCount).to.equal(5);
         });
     });
-  });
+
+    it('should continue retry while error is matched by function', function() {
+      var callback = sinon.stub();
+
+      callback.rejects(this.soRejected);
+      callback.onCall(4).resolves(this.soResolved);
+
+      return expect(
+        retry(callback, {
+          max: 15,
+          backoffBase: 0,
+          match: (err) => err instanceof Error
+        })
+      )
+        .to.eventually.equal(this.soResolved)
+        .then(function() {
+          expect(callback.callCount).to.equal(5);
+        });
+    });
+});
 
   describe('options.backoff', function() {
     it('should resolve after 5 retries and an eventual delay over 1800ms using default backoff', function() {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -294,6 +294,27 @@ describe(PROMISE_TYPE, function() {
           expect(callback.callCount).to.equal(5);
         });
     });
+
+    it('should continue retry while error is matched by a function in array', function() {
+      var callback = sinon.stub();
+
+      callback.rejects(this.soRejected);
+      callback.onCall(4).resolves(this.soResolved);
+
+      return expect(
+        retry(callback, {
+          max: 15,
+          backoffBase: 0,
+          match: [
+            (err) => err instanceof Error
+          ]
+        })
+      )
+        .to.eventually.equal(this.soResolved)
+        .then(function() {
+          expect(callback.callCount).to.equal(5);
+        });
+    });
 });
 
   describe('options.backoff', function() {


### PR DESCRIPTION
adds the ability to use an arbitrary function as the match, this lets you use more complex logic than just matching error strings, like:

```js
// retry on all errors but 404, currently not possible with existing impl
match: (err) => err.status !== 404
```