### PR TITLE
Fix issue on retryDelay calculation :tea:

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,9 +88,11 @@ module.exports = function retryAsPromised(callback, options) {
         });
         if (!shouldRetry) return reject(err);
 
-        var retryDelay = Math.pow(
-          options.backoffBase,
-          Math.pow(options.backoffExponent, options.$current - 1)
+        var retryDelay = Math.round(
+          Math.pow(
+              options.backoffBase,
+              Math.pow(options.backoffExponent, options.$current - 1)
+          )
         );
 
         // Do some accounting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retry-as-promised",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Retry a failed promise",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retry-as-promised",
-  "version": "3.2.1",
+  "version": "3.2.0",
   "description": "Retry a failed promise",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In retry function we use `setTimeout`, but `setTimeout` only accept Int type. So we need to prevent floating number of this function.

```
          backoffTimeout = setTimeout(function() {
            retryAsPromised(callback, options)
              .then(resolve)
              .catch(reject);
          }, retryDelay);
```