### PR TITLE
Remove any-promise, resolves #27

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Promise = require('any-promise');
 var util = require('util');
 var format = util.format;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,11 +67,6 @@
         "color-convert": "^2.0.1"
       }
     },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
-    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -110,12 +105,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "brace-expansion": {
@@ -755,12 +744,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "randombytes": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Retry a failed promise",
   "main": "index.js",
   "scripts": {
-    "test": "PROMISE_TYPE=bluebird npm run test-raw && PROMISE_TYPE=q npm run test-raw",
-    "test-raw": "cross-env DEBUG=retry-as-promised* ./node_modules/.bin/mocha --check-leaks --colors -t 10000 --reporter spec test/promise.test.js"
+    "test": "cross-env DEBUG=retry-as-promised* ./node_modules/.bin/mocha --check-leaks --colors -t 10000 --reporter spec test/promise.test.js"
   },
   "repository": {
     "type": "git",
@@ -22,17 +21,14 @@
     "url": "https://github.com/mickhansen/retry-as-promised/issues"
   },
   "homepage": "https://github.com/mickhansen/retry-as-promised",
-  "dependencies": {
-  },
+  "dependencies": {},
   "files": [],
   "devDependencies": {
-    "bluebird": "^3.5.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.2.0",
     "mocha": "^9.1.1",
     "moment": "^2.10.6",
-    "q": "^1.5.1",
     "sinon": "^7.0.0",
     "sinon-chai": "^3.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/mickhansen/retry-as-promised",
   "dependencies": {
-    "any-promise": "^1.3.0"
   },
   "files": [],
   "devDependencies": {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -8,9 +8,7 @@ var delay = ms => new Promise(_ => setTimeout(_, ms));
 chai.use(require('chai-as-promised'));
 sinon.usingPromise(Promise);
 
-var PROMISE_TYPE = process.env.PROMISE_TYPE;
-
-describe(PROMISE_TYPE, function() {
+describe('Global Promise', function() {
   var retry = require('../')
 
   beforeEach(function() {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -11,8 +11,6 @@ sinon.usingPromise(Promise);
 var PROMISE_TYPE = process.env.PROMISE_TYPE;
 
 describe(PROMISE_TYPE, function() {
-  require('any-promise/register/' + PROMISE_TYPE);
-  var Promise = require('any-promise');
   var retry = require('../')
 
   beforeEach(function() {
@@ -338,10 +336,10 @@ describe(PROMISE_TYPE, function() {
     it('should resolve after 1 retry and initial delay equal to the backoffBase', async function() {
       var initialDelay = 100;
       var callback = sinon.stub();
-      
+
       callback.onCall(0).rejects(this.soRejected);
       callback.onCall(1).resolves(this.soResolved);
-      
+
       var startTime = moment();
       const result = await retry(callback, {
           max: 2,
@@ -349,7 +347,7 @@ describe(PROMISE_TYPE, function() {
           backoffExponent: 3
         });
       var endTime = moment();
-        
+
       expect(result).to.equal(this.soResolved);
       expect(callback.callCount).to.equal(2);
       // allow for some overhead


### PR DESCRIPTION
Since the great promise war is over (and because any-promise relies on a global window object), let's drop the any-promise package and the bluebird / q packages too.